### PR TITLE
Fcc 114 timestamp for predictions

### DIFF
--- a/Analytics/models/prediction_results.py
+++ b/Analytics/models/prediction_results.py
@@ -107,6 +107,8 @@ class PredictionResults(db.Model):
         to create the prediction result
         :param model: the model class corresponding to the table which was
         used to generate predictions
+        :return: whether the prediction was created before the import of more 
+        recent data
         """
 
         recent_import_entry = db.session.query(model).order_by(desc(

--- a/Analytics/models/user_predictions.py
+++ b/Analytics/models/user_predictions.py
@@ -88,6 +88,7 @@ class UserPredictions(db.Model):
     def find_by_user_id(cls, user_id: int) -> db.Model:
         """
         Return the Prediction Result ids that matches the user_id argument
+        :param user_id: id of user
         """
         return cls.query.filter_by(user_id=user_id).all()
 
@@ -95,15 +96,33 @@ class UserPredictions(db.Model):
     def find_by_pred_id(cls, pred_id: int) -> db.Model:
         """
         Return the entries which match the user_id argument
+        :param pred_id: id of prediction result
         """
         return cls.query.filter_by(pred_result_id=pred_id).all()
 
     @classmethod
-    def entry_exists(cls, user_id: int, pred_id) -> db.Model:
+    def get_entry(cls, user_id: int, pred_id) -> db.Model:
         """
         Return the prediction result ids that matches the user_id and
         pred_result_id arguments
+        :param user_id: id of user requesting the prediction
+        :param pred_id: id of prediction result
         """
         return cls.query.filter_by(user_id=user_id,
                                    pred_result_id=pred_id).first()
+
+    @classmethod
+    def add_entry(cls, user_id, prediction_result_id):
+        """
+        Add an entry into the user predictions table if it does not exists
+        :param user_id: id of user requesting the prediction
+        :param prediction_result_id: id of prediction result
+        """
+        if user_id:
+            if not cls.get_entry(user_id, prediction_result_id):
+                user_prediction_entry = UserPredictions(user_id,
+                                                        prediction_result_id,
+                                                        datetime.now())
+                user_prediction_entry.save()
+                user_prediction_entry.commit()
 

--- a/Analytics/models/user_predictions.py
+++ b/Analytics/models/user_predictions.py
@@ -89,6 +89,7 @@ class UserPredictions(db.Model):
         """
         Return the Prediction Result ids that matches the user_id argument
         :param user_id: id of user
+        :return: the user predictions entry/entries that match the user_id argument
         """
         return cls.query.filter_by(user_id=user_id).all()
 
@@ -97,6 +98,7 @@ class UserPredictions(db.Model):
         """
         Return the entries which match the user_id argument
         :param pred_id: id of prediction result
+        :return: the user predictions entry/entries that match the pred_id argument
         """
         return cls.query.filter_by(pred_result_id=pred_id).all()
 
@@ -107,6 +109,8 @@ class UserPredictions(db.Model):
         pred_result_id arguments
         :param user_id: id of user requesting the prediction
         :param pred_id: id of prediction result
+        :return: the user predictions entry which matched the pred_id and user_id
+        argument
         """
         return cls.query.filter_by(user_id=user_id,
                                    pred_result_id=pred_id).first()

--- a/Analytics/models/user_predictions.py
+++ b/Analytics/models/user_predictions.py
@@ -22,7 +22,7 @@ class UserPredictions(db.Model):
     timestamp = db.Column(db.DateTime)
 
     def __init__(self, user_id: int, pred_result_id: int, timestamp: datetime =
-                 datetime.utcnow()):
+                 datetime.now()):
         """
         Initialise the User Predictions object instance
         :param user_id: users id in the users table
@@ -90,6 +90,13 @@ class UserPredictions(db.Model):
         Return the Prediction Result ids that matches the user_id argument
         """
         return cls.query.filter_by(user_id=user_id).all()
+
+    @classmethod
+    def find_by_pred_id(cls, pred_id: int) -> db.Model:
+        """
+        Return the entries which match the user_id argument
+        """
+        return cls.query.filter_by(pred_result_id=pred_id).all()
 
     @classmethod
     def entry_exists(cls, user_id: int, pred_id) -> db.Model:

--- a/Analytics/resources/predict.py
+++ b/Analytics/resources/predict.py
@@ -85,7 +85,3 @@ def predict(values, timestamp, n_pred):
 	except Exception as e:
 		#### TODO log the error
 			return None, None, None
-
-
-
-

--- a/Analytics/resources/predict.py
+++ b/Analytics/resources/predict.py
@@ -87,3 +87,5 @@ def predict(values, timestamp, n_pred):
 			return None, None, None
 
 
+
+

--- a/Analytics/resources/request_for_data.py
+++ b/Analytics/resources/request_for_data.py
@@ -508,7 +508,7 @@ class RequestForData(Resource):
                             "Predictions": _pred
                             }
 
-        pred_data = {"status": "task complete", "qresult": result}
+        pred_data = {"status": "task complete", "result": result}
         return pred_data
 
         

--- a/Analytics/resources/request_for_data.py
+++ b/Analytics/resources/request_for_data.py
@@ -64,7 +64,6 @@ from models.location import Location
 from models.unit import Unit
 from models.prediction_results import PredictionResults
 from models.user_predictions import UserPredictions
-from resources.predict import predict
 from resources.helper_functions import is_number
 from resources.request_grouped import request_grouped_data, request_harmonised_data
 
@@ -318,7 +317,7 @@ class RequestForData(Resource):
                             .all()
             else:
                 if operation is None:
-
+                    db.metadata.clear()
                     ### refactored the query to fetch the latest values by default
                     values = db.session.query(model).order_by(sqlalchemy.desc(
                         model.api_timestamp)).limit(limit).all() # \
@@ -450,63 +449,49 @@ class RequestForData(Resource):
             for val in values:
                 _data.append(float(val.value))
                 _timestamps.append(val.api_timestamp)
-            
+
             predict_from_db = PredictionResults.find_by_prediction_args(
                 attribute_table, sensor_id, n_pred)
 
-            if predict_from_db: # use a cached result
-                predict_from_db.updated_timestamp = datetime.now()
-                predict_from_db.save()
-                predict_from_db.commit()
-                if u_id:
-                    if not UserPredictions.entry_exists(u_id,
-                                                        predict_from_db.id):
+            if predict_from_db:
+                existing_user_result = UserPredictions.get_entry(u_id,
+                                                           predict_from_db.id)
 
-                        user_prediction_entry = UserPredictions(u_id,
-                                                                predict_from_db.id,
-                                                                datetime.now())
-                        user_prediction_entry.save()
-                        user_prediction_entry.commit()
+                if existing_user_result and predict_from_db.is_stale(model):
+                    existing_user_result.delete()
+                    existing_user_result.commit()
 
-                result = {
-                    "Sensor_id": predict_from_db.sensor_id,
-                    "Forcasting_engine": predict_from_db.forcasting_engine,
-                    "Mean_Absolute_Percentage_Error":
-                        predict_from_db.mean_absolute_percentage_error,
-                    "Predictions": predict_from_db.result
-                }
+                    if not UserPredictions.find_by_pred_id(predict_from_db.id):
+                        predict_from_db.delete()
+                        predict_from_db.commit()
+
+                    result = PredictionResults.generate_predictions_results(
+                        attribute_table, sensor_id, n_pred, _data, _timestamps)
+                    UserPredictions.add_entry(u_id, result["Prediction_id"])
+
+
+                else:
+                    # use a cached result
+                    predict_from_db.updated_timestamp = datetime.now()
+                    predict_from_db.save()
+                    predict_from_db.commit()
+                    UserPredictions.add_entry(u_id, predict_from_db.id)
+
+                    result = {
+                        "Sensor_id": predict_from_db.sensor_id,
+                        "Forcasting_engine": predict_from_db.forcasting_engine,
+                        "Mean_Absolute_Percentage_Error":
+                            predict_from_db.mean_absolute_percentage_error,
+                        "Prediction_id": predict_from_db.id,
+                        "Predictions": predict_from_db.result
+                    }
 
             else:
-                _pred, _mape, _method = predict(_data, _timestamps, n_pred)
 
-                if sensor_id:
-                    _sensorid = sensor_id
-                else:
-                    _sensorid = "All sensors"
+                result = PredictionResults.generate_predictions_results(
+                    attribute_table, sensor_id, n_pred, _data, _timestamps)
 
-                prediction_result = PredictionResults(_method, _mape,
-                                                      attribute_table,
-                                                      _sensorid, n_pred,
-                                                      _pred, datetime.now(),
-                                                      datetime.now())
-                prediction_result.save()
-                prediction_result.commit()
-
-                if u_id is not None:
-                    user_prediction_entry = UserPredictions(u_id,
-                                                            prediction_result.id,
-                                                            datetime.now())
-                    user_prediction_entry.save()
-                    user_prediction_entry.commit()
-
-                PredictionResults.enforce_lru_replacement_policy()
-
-                result = {
-                            "Sensor_id": _sensorid,
-                            "Forcasting_engine": _method,
-                            "Mean_Absolute_Percentage_Error": _mape,
-                            "Predictions": _pred
-                            }
+                UserPredictions.add_entry(u_id, result["Prediction_id"])
 
         pred_data = {"status": "task complete", "result": result}
         return pred_data

--- a/Analytics/resources/themes/add_theme.py
+++ b/Analytics/resources/themes/add_theme.py
@@ -36,7 +36,7 @@ class AddTheme(Resource):
         args = self.reqparser.parse_args()
 
         # Check the theme name is not empty, abort if it is empty
-        if if not args["name"]:
+        if not args["name"]:
             return {'error': 'Theme cannot be empty', 'name': "''"}, HTTPStatus.BAD_REQUEST
 
         # Check theme does not exist (avoid duplicates)

--- a/Analytics/test_celery_prediction.py
+++ b/Analytics/test_celery_prediction.py
@@ -2,9 +2,10 @@ import unittest
 
 from app import create_app
 from models.users import Users
+from models.user_predictions import UserPredictions
 
 
-class ForgotPasswordTestCase(unittest.TestCase):
+class CelryTestCase(unittest.TestCase):
     """
     Test whether user can request and receive a prediction task asynchronously
     """
@@ -17,10 +18,19 @@ class ForgotPasswordTestCase(unittest.TestCase):
         self.testing_client_context = self.test_app.app_context()
         self.testing_client_context.push()
 
+        self.dummy_user = Users("Joey", "joey@FCC.com",
+                                Users.generate_hash("1234".encode(
+                                    "utf8")).decode("utf8"), True, True)
+        self.dummy_user.save()
+        self.dummy_user.commit()
+
     def tearDown(self):
         """ Remove testing client context """
 
         self.testing_client_context.pop()
+
+        self.dummy_user.delete()
+        self.dummy_user.commit()
 
     def test_async_prediction(self):
         """
@@ -57,4 +67,39 @@ class ForgotPasswordTestCase(unittest.TestCase):
             response_poll_json = response_poll.get_json()
 
         self.assertEqual(response_poll_json["state"], "SUCCESS")
+
+    def test_adding_prediction_per_user(self):
+        """
+        Test whether a prediction result is associated with a user in the
+        userpredictions table
+        """
+
+        response = self.testing_client.get(
+            '/data?limit=3&attributedata=NO2&predictions=True'
+            '&n_predictions=3')
+        self.assertIn(b"Forecasting engine making predictions", response.data)
+        self.assertIn(b"task_id", response.data)
+        response_json = response.get_json()
+        task_id = response_json[1]["task_id"]
+
+        response_poll = self.testing_client.get("/pred_status?task_id={}"
+                                                .format(task_id))
+
+        response_poll_json = response_poll.get_json()
+        while response_poll_json["state"] in ["PENDING", "PROGRESS"]:
+            response_poll = self.testing_client.get("/pred_status?task_id={}"
+                                                    .format(task_id))
+            response_poll_json = response_poll.get_json()
+
+        self.assertEqual(response_poll_json["state"], "SUCCESS")
+        self.assertIsNotNone(response_poll_json["result"]["Prediction_id"])
+
+
+
+
+
+
+
+
+
 

--- a/Analytics/test_celery_prediction.py
+++ b/Analytics/test_celery_prediction.py
@@ -93,13 +93,3 @@ class CelryTestCase(unittest.TestCase):
 
         self.assertEqual(response_poll_json["state"], "SUCCESS")
         self.assertIsNotNone(response_poll_json["result"]["Prediction_id"])
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
**Updated files**

/models/prediction_results.py - split the timestamp field into a created timestamp and an updated timestamp. Added a method to determine if a prediction result has become stale as result of new data being imported into it's attribute table and moved the predict method into the class 

/models/user_predictions.py - renamed the entry_exist method to get_entry. Added the add_entry method

/resources/request_for_data - changed logic of requesting predictions to enforce that stale predictions will be replaced by a newer version. 

/Analytics/test_celery_prediction - added an additional test case to check if the correct prediction id is returned