### PR TITLE
Fcc 121 importer retry endpoint

### DIFF
--- a/Analytics/importers/scheduler_new.py
+++ b/Analytics/importers/scheduler_new.py
@@ -35,7 +35,7 @@ class Scheduler(object):
     status_tracker = ImporterStatus.get_importer_status()
 
     @status_tracker.changed.register
-    def status_has_changed(self, status: ImporterStatuses):
+    def status_has_changed(self, status: ImporterStatus):
         """
         Receive the status of an importer and persist it to the Importer
         Status table

--- a/Analytics/resources/import_retry.py
+++ b/Analytics/resources/import_retry.py
@@ -1,0 +1,79 @@
+import datetime
+import importlib
+import logging
+
+from flask_restful import Resource, reqparse
+from flask_jwt_extended import jwt_required, get_jwt_claims
+
+from db import db
+from importers.state_decorator import ImporterStatus
+from models.importer_status import ImporterStatuses
+from models.api import API
+
+logging.basicConfig(level='INFO', filename='importers.log', filemode='a')
+logger = logging.getLogger(__name__)
+
+
+class ImportRetry(Resource):
+    """
+    API endpoint, rerun an importer that has failed.
+    """
+
+    status_tracker = ImporterStatus.get_importer_status()
+    parser = reqparse.RequestParser()
+    parser.add_argument("api_id")
+
+    @status_tracker.changed.register
+    def status_has_changed(self, status: ImporterStatus):
+        """
+        Receive the status of an importer and persist it to the Importer
+        Status table
+        :param status: Status object defining the state of an importer
+        """
+        logger.info("{}".format(status))
+        importer_status = ImporterStatuses.find_by_name(status.name)
+        if importer_status:
+            if status.state == "success":
+                importer_status.state = "success"
+            else:
+                importer_status.state = "failure"
+                importer_status.reason = status.reason
+                importer_status.trace = status.stack_trace
+
+            importer_status.timestamp = datetime.datetime.now()
+            importer_status.commit()
+
+    @jwt_required
+    def post(self) -> (str, int):
+        """
+        POST request, allow an admin user to run the importer which
+        corresponds to the api_id argument
+        :return: A message that indicates whether or not the importer was
+                 executed
+        """
+        args = self.parser.parse_args()
+        if get_jwt_claims()["admin"]:
+            if self.retry_importer(args["api_id"]):
+                return {"message": "success"}, 200
+            else:
+                return {"message": "importer could not be found"}, 200
+        else:
+            return {"message": "Not Authorised"}, 403
+
+    @staticmethod
+    def retry_importer(api_id) -> bool:
+        """
+        Execute the importer that corresponds to the api_id arguments
+        :param api_id: id of an entry in the api table
+        :return: whether the was importer executed
+        """
+        api_entry = API.get_by_api_id(api_id)
+        if api_entry:
+            _module, _class = api_entry.api_class.rsplit('.', 1)
+            data_class = getattr(importlib.import_module(_module), _class)
+            _d_class = data_class()
+            _d_class._create_datasource()
+
+            return True
+        else:
+            return False

--- a/Analytics/resources/import_retry.py
+++ b/Analytics/resources/import_retry.py
@@ -30,7 +30,7 @@ class ImportRetry(Resource):
         Status table
         :param status: Status object defining the state of an importer
         """
-        logger.info("{}".format(status))
+        logger.info(status)
         importer_status = ImporterStatuses.find_by_name(status.name)
         if importer_status:
             if status.state == "success":
@@ -44,7 +44,7 @@ class ImportRetry(Resource):
             importer_status.commit()
 
     @jwt_required
-    def post(self) -> (str, int):
+    def post(self) -> (dict, int):
         """
         POST request, allow an admin user to run the importer which
         corresponds to the api_id argument

--- a/Analytics/test_importer_retry.py
+++ b/Analytics/test_importer_retry.py
@@ -1,0 +1,71 @@
+import unittest
+from datetime import datetime
+
+from app import create_app
+from models.importer_status import ImporterStatuses
+from models.users import Users
+
+
+class ImporterRetryEndpointTestCase(unittest.TestCase):
+    """
+    Test whether an admin user can request for a retry of a failed importer
+    """
+
+    def setUp(self):
+        """ Create testing client version of flask app """
+
+        self.test_app = create_app(DATABASE_NAME='scheduler',
+                                   TESTING=True)
+        self.testing_client = self.test_app.test_client()
+        self.testing_client_context = self.test_app.app_context()
+        self.testing_client_context.push()
+
+    def tearDown(self):
+        """ Remove testing client context """
+
+        self.testing_client_context.pop()
+
+    def test_request_for_retry_success(self):
+        """
+        Test whether the correct response is returned when a importer
+        retry succeeds
+        """
+        importer = ImporterStatuses.find_by_api_id(2)
+        current_timestamp = importer.timestamp
+        access_token_header = self.generate_access_token()
+        response = self.testing_client.post('/importer_retry', data=dict(
+            api_id=importer.api_id), headers=access_token_header)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"success", response.data)
+        updated_importer = ImporterStatuses.find_by_api_id(2)
+        self.assertGreater(updated_importer.timestamp, current_timestamp)
+
+    def test_request_for_retry_failure(self):
+        """
+        Test whether the correct response is returned when a importer
+        retry fails
+        """
+        access_token_header = self.generate_access_token()
+        response = self.testing_client.post('/importer_retry', data=dict(
+            api_id=999999), headers=access_token_header)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"could not be found", response.data)
+
+    def generate_access_token(self) -> dict:
+        """
+        Generate admin access JWT.
+        :return: a HTTP authorization header containing a admin access token
+        """
+
+        admin_user = Users("Admin user", "admin@FCC.com",
+                           Users.generate_hash(b"1234").decode("utf8"), True,
+                           True)
+        admin_user.save()
+        admin_user.commit()
+        response_login = self.testing_client.post('/login', data=dict(
+            email="admin@FCC.com", password="1234", remember=True))
+        response_login_json = response_login.get_json()
+        admin_user.delete()
+        admin_user.commit()
+        return {'Authorization': 'Bearer {}'.format(
+            response_login_json["access_token"])}


### PR DESCRIPTION
**New Files**
Analytics/resources/import_retry.py - endpoint that allows an admin user to retry a failed importer and then persists the state of the importer after it has executed
Analytics/test_importer_retry.py - tests the functionality of the /importer_retry endpoint 
