### PR TITLE
Fcc 143 request for moving sensor data

### DIFF
--- a/Analytics/app.py
+++ b/Analytics/app.py
@@ -36,6 +36,10 @@ from resources.moving_sensors import CreateTracker
 from resources.moving_sensors import DeleteTracker
 from resources.moving_sensors import GetTracker
 from resources.moving_sensors import UpdateTracker
+from resources.moving_sensors.add_new_location_data import AddNewLocationData
+from resources.moving_sensors.delete_location_data import DeleteLocationData
+from resources.moving_sensors.get_location_data import GetLocationData
+from resources.moving_sensors.remove_location_data import WindowLocationData
 from resources.refresh_token import TokenRefresh
 from resources.register import Register
 from resources.request_for_data import PredictionStatus
@@ -194,5 +198,10 @@ def create_app(**config_overrides):
     api.add_resource(DeleteTracker, '/moving/delete_tracker')
     api.add_resource(UpdateTracker, '/moving/update_tracker')
     api.add_resource(GetTracker, '/moving/get_tracker')
+
+    api.add_resource(AddNewLocationData, '/moving/add_new_data')
+    api.add_resource(DeleteLocationData, '/moving/delete_location_data')
+    api.add_resource(GetLocationData, '/moving/get_loc_data')
+    api.add_resource(WindowLocationData, '/moving/window_data')
 
     return app

--- a/Analytics/app.py
+++ b/Analytics/app.py
@@ -58,6 +58,7 @@ from resources.units.delete_unit import DeleteUnitOfMeasurement
 from resources.units.get_all_units import GetAllUnitsOfMeasure
 from resources.units.get_unit import GetUnitOfMeasure
 from resources.units.update_unit import UpdateUnitOfMeasure
+from resources.moving_sensors import GetDummyData
 
 
 def create_app(**config_overrides):
@@ -203,5 +204,6 @@ def create_app(**config_overrides):
     api.add_resource(DeleteLocationData, '/moving/delete_location_data')
     api.add_resource(GetLocationData, '/moving/get_loc_data')
     api.add_resource(WindowLocationData, '/moving/window_data')
+    api.add_resource(GetDummyData, '/moving/get_dummy_data')
 
     return app

--- a/Analytics/app.py
+++ b/Analytics/app.py
@@ -213,5 +213,4 @@ def create_app(**config_overrides):
     api.add_resource(ExportToKML, '/moving/export_kml')
     api.add_resource(GetDummyData, '/moving/fetch_dummy_data')
 
-
     return app

--- a/Analytics/models/pin_location_data.py
+++ b/Analytics/models/pin_location_data.py
@@ -3,7 +3,7 @@ import random
 from datetime import datetime, timedelta
 from typing import Union
 
-from sqlalchemy import and_, func
+from sqlalchemy import and_, func, desc
 from sqlalchemy.exc import IntegrityError
 
 from db import db
@@ -19,12 +19,15 @@ class Tracker(db.Model):
     __tablename__ = 'tracker'
 
     id = db.Column(db.Text, unique=True, primary_key=True, autoincrement=False)
+    sub_theme_id = db.Column(db.Integer, db.ForeignKey('subtheme.id'),
+                             nullable=False)
+    sub_theme = db.relationship("SubTheme")
     description = db.Column(db.Text, nullable=True)
     activated_date = db.Column(db.DateTime, default=datetime.now)
     loc_data = db.relationship("LocationData", back_populates="tracker",
                                primaryjoin="and_(Tracker.id==LocationData.tracker_id)")
 
-    def __init__(self, tracker_id: str, description: str = "",
+    def __init__(self, tracker_id: str, subtheme_id:int, description: str = "",
                  activated_date: datetime.timestamp = datetime.utcnow()) -> None:
         """
         Instantiate Tracker model
@@ -33,6 +36,7 @@ class Tracker(db.Model):
         :param activated_date: Date Activated
         """
         self.id = tracker_id
+        self.sub_theme_id = subtheme_id
         self.activated_date = activated_date
         self.description = description
 
@@ -121,6 +125,23 @@ class Tracker(db.Model):
         :return: A Tracker with the tracker_id
         """
         return cls.query.filter_by(id=tracker_id).first()
+
+    @classmethod
+    def get_by_subtheme_id(cls, subtheme_id: str) -> db.Model:
+        """
+        Get Tracker by subtheme id
+        :param subtheme_id: Subtheme id
+        :return: A Tracker with the subtheme_id
+        """
+        return cls.query.filter_by(sub_theme_id=subtheme_id).all()
+
+    @classmethod
+    def get_all(cls) -> db.Model:
+        """
+        Get all Trackers
+        :return: All entries in Tracker table
+        """
+        return cls.query.all()
 
 
 class LocationData(db.Model):
@@ -339,6 +360,18 @@ class LocationData(db.Model):
             return cls.query.filter_by(tracker_id=tracker_id)
 
     @classmethod
+    def get_by_tracker_id_with_limit(cls, tracker_id: str,
+                                     limit: int) -> Union[db.Model, list]:
+        """
+        Get limit number of entries which contain the corresponding tracker_id
+        :param tracker_id: Tracker id.
+        :param limit: number of entries to return.
+        :return: Entries related to the Tracker Id passed.
+        """
+        return cls.query.filter_by(tracker_id=tracker_id).order_by(desc(
+            LocationData.timestamp)).limit(limit)
+
+    @classmethod
     def get_by_id(cls, loc_id: str) -> db.Model:
         """
         Get LocationData by id
@@ -346,3 +379,35 @@ class LocationData(db.Model):
         :return: LocationData entry
         """
         return cls.query.filter_by(id=loc_id).first()
+
+    @classmethod
+    def get_tracker_attributes(cls, tracker_id: str) -> Union[list, None]:
+        """
+        Get the attributes a tracker records
+        :param tracker_id: A tracker id
+        :return: The attributes a tracker senses
+        """
+        tracker = cls.query.filter_by(tracker_id=tracker_id).first()
+        if tracker:
+            tracker_dict = dict(tracker.value)
+            return [*tracker_dict]
+        else:
+            return None
+
+    @classmethod
+    def does_tracker_record(cls, tracker_id: str, attr: str) -> Union[bool,
+                                                               None]:
+        """
+        Get the attributes a tracker records
+        :param tracker_id: A tracker id
+        :return: The attributes a tracker senses
+        """
+        tracker = cls.query.filter_by(tracker_id=tracker_id).first()
+        if tracker:
+            tracker_dict = dict(tracker.value)
+            if attr in [*tracker_dict]:
+                return True
+            else:
+                return False
+        else:
+            return None

--- a/Analytics/models/pin_location_data.py
+++ b/Analytics/models/pin_location_data.py
@@ -100,8 +100,8 @@ class Tracker(db.Model):
         except IntegrityError as ite:
             db.session.rollback()
             logger.error(
-                "Error occurred when deleting Tracker from session: id {}".format(
-                    self.id),
+                "Error occurred when deleting Tracker "
+                "from session: id {}".format(self.id),
                 ite.with_traceback(ite.__traceback__))
 
     @staticmethod
@@ -368,7 +368,8 @@ class LocationData(db.Model):
 
         if not tracker_id:
             return cls.query.filter(and_(cls.measurement_date >= start_date,
-                                         cls.measurement_date <= end_date)).all()
+                                         cls.measurement_date
+                                         <= end_date)).all()
 
         return cls.query.join(Tracker).filter(Tracker.id == tracker_id) \
             .filter(and_(cls.measurement_date >= start_date,
@@ -443,11 +444,12 @@ class LocationData(db.Model):
             return None
 
     @classmethod
-    def does_tracker_record(cls, tracker_id: str, attr: str) -> Union[bool,
-                                                               None]:
+    def does_tracker_record(cls, tracker_id: str,
+                            attr: str) -> Union[bool, None]:
         """
         Get the attributes a tracker records
         :param tracker_id: A tracker id
+        :param attr: name of attribute to check
         :return: The attributes a tracker senses
         """
         tracker = cls.query.filter_by(tracker_id=tracker_id).first()

--- a/Analytics/models/pin_location_data.py
+++ b/Analytics/models/pin_location_data.py
@@ -26,10 +26,12 @@ class Tracker(db.Model):
     description = db.Column(db.Text, nullable=True)
     activated_date = db.Column(db.DateTime, default=datetime.now)
     loc_data = db.relationship("LocationData", back_populates="tracker",
-                               primaryjoin="and_(Tracker.id==LocationData.tracker_id)")
+                               primaryjoin=
+                               "and_(Tracker.id==LocationData.tracker_id)")
 
-    def __init__(self, tracker_id: str, subtheme_id:int, description: str = "",
-                 activated_date: datetime.timestamp = datetime.utcnow()) -> None:
+    def __init__(self, tracker_id: str, subtheme_id: int, description: str = "",
+                 activated_date: datetime.timestamp =
+                 datetime.utcnow()) -> None:
         """
         Instantiate Tracker model
         :param tracker_id: New Tracker Id

--- a/Analytics/models/pin_location_data.py
+++ b/Analytics/models/pin_location_data.py
@@ -29,8 +29,8 @@ class Tracker(db.Model):
                                primaryjoin=
                                "and_(Tracker.id==LocationData.tracker_id)")
 
-    def __init__(self, tracker_id: str, subtheme_id: int, description: str = "",
-                 activated_date: datetime.timestamp =
+    def __init__(self, tracker_id: str, subtheme_id: int,
+                 description: str = "", activated_date: datetime.timestamp =
                  datetime.utcnow()) -> None:
         """
         Instantiate Tracker model

--- a/Analytics/resources/moving_sensors/get_dummy_data.py
+++ b/Analytics/resources/moving_sensors/get_dummy_data.py
@@ -122,7 +122,7 @@ class GetDummyData(Resource):
         tracker.commit()
         return tid
 
-    def add_location_data(self, tracker_id: str, timestamp: str, latitude: float,
+    def add_location_data(self, tracker_id: str, measurement_date: str, latitude: float,
                           longitude: float, speed: float, heading: float,
                           elevation: float, charger: bool, battery: float,
                           signalquality: int, satcnt: int) -> None:

--- a/Analytics/resources/moving_sensors/get_dummy_data.py
+++ b/Analytics/resources/moving_sensors/get_dummy_data.py
@@ -162,7 +162,7 @@ class GetDummyData(Resource):
                          "co2": str(random.uniform(0, 100))}
 
             loc_data = LocationData.builder(tracker_id=tracker_id,
-                                            timestamp=measurement_date,
+                                            measurement_date=measurement_date,
                                             latitude=latitude,
                                             longitude=longitude, speed=speed,
                                             heading=heading, elevation=elevation,

--- a/Analytics/resources/moving_sensors/get_dummy_data.py
+++ b/Analytics/resources/moving_sensors/get_dummy_data.py
@@ -108,9 +108,10 @@ class GetDummyData(Resource):
         tracker.commit()
         return tid
 
-    def add_location_data(self, tracker_id: str, timestamp: str, latitude: float, longitude: float, speed: float,
-                          heading: float, elevation: float, charger: bool, battery: float, signalquality: int,
-                          satcnt: int) -> None:
+    def add_location_data(self, tracker_id: str, timestamp: str, latitude: float,
+                          longitude: float, speed: float, heading: float,
+                          elevation: float, charger: bool, battery: float,
+                          signalquality: int, satcnt: int) -> None:
         """
         Create LocationData
         :param tracker_id: Trackers Id
@@ -146,10 +147,15 @@ class GetDummyData(Resource):
                 value = {"no2": str(random.uniform(0, 100)),
                          "co2": str(random.uniform(0, 100))}
 
-            loc_data = LocationData.builder(tracker_id=tracker_id, timestamp=timestamp, latitude=latitude,
-                                            longitude=longitude, speed=speed, heading=heading, elevation=elevation,
-                                            sat_cnt=satcnt, fix_quality=1, signal_quality=signalquality,
-                                            battery=battery, charger=charger, value=value)
+            loc_data = LocationData.builder(tracker_id=tracker_id,
+                                            timestamp=timestamp,
+                                            latitude=latitude,
+                                            longitude=longitude, speed=speed,
+                                            heading=heading, elevation=elevation,
+                                            sat_cnt=satcnt, fix_quality=1,
+                                            signal_quality=signalquality,
+                                            battery=battery, charger=charger,
+                                            value=value)
             loc_data.save()
             loc_data.commit()
         except IntegrityError as ite:

--- a/Analytics/resources/moving_sensors/get_dummy_data.py
+++ b/Analytics/resources/moving_sensors/get_dummy_data.py
@@ -71,7 +71,6 @@ class GetDummyData(Resource):
             moving_sensor_subtheme.commit()
             moving_sensor_subtheme_id = moving_sensor_subtheme.id
 
-
         # Trackers must be unique, Fetch trackers and make dB entries for each unique tracker
         unique_tracker_ids = df["tracker"].unique()
 

--- a/Analytics/resources/moving_sensors/get_dummy_data.py
+++ b/Analytics/resources/moving_sensors/get_dummy_data.py
@@ -122,10 +122,11 @@ class GetDummyData(Resource):
         tracker.commit()
         return tid
 
-    def add_location_data(self, tracker_id: str, measurement_date: str, latitude: float,
-                          longitude: float, speed: float, heading: float,
-                          elevation: float, charger: bool, battery: float,
-                          signalquality: int, satcnt: int) -> None:
+    def add_location_data(self, tracker_id: str, measurement_date: str,
+                          latitude: float, longitude: float, speed: float,
+                          heading: float, elevation: float, charger: bool,
+                          battery: float, signalquality: int,
+                          satcnt: int) -> None:
         """
         Create LocationData
         :param tracker_id: Trackers Id
@@ -165,8 +166,9 @@ class GetDummyData(Resource):
                                             measurement_date=measurement_date,
                                             latitude=latitude,
                                             longitude=longitude, speed=speed,
-                                            heading=heading, elevation=elevation,
-                                            sat_cnt=satcnt, fix_quality=1,
+                                            heading=heading,
+                                            elevation=elevation,sat_cnt=satcnt,
+                                            fix_quality=1,
                                             signal_quality=signalquality,
                                             battery=battery, charger=charger,
                                             value=value)

--- a/Analytics/resources/request_for_data.py
+++ b/Analytics/resources/request_for_data.py
@@ -28,6 +28,8 @@ Note: If no parameters are passed then by default all the themes are returned
     grouped: boolean specifying whether the sensor records are to be grouped at hourly intervals
         per_sensor: boolean specifying whether the sensor records are to be grouped at hourly intervals and 
                     per individual sensor. Defaults to False
+    moving: boolean specifying whether data related to moving sensors is to be
+            returned
 
     Note: fromdate and todate both needs to be present in order for date filtering to work
 
@@ -182,17 +184,19 @@ class RequestForData(Resource):
                     if sensor_id == 'all':
                         all_trackers =  Tracker.get_all()
                         if all_trackers:
-                            result = [{"id": tracker.id,
-                                       "attributes" :
-                                           LocationData.get_tracker_attributes(tracker.id)}
-                                      for tracker in all_trackers]
+                            result = [
+                                {"id": tracker.id,
+                                 "attributes":
+                                     LocationData.get_tracker_attributes(tracker.id)
+                                 } for tracker in all_trackers
+                            ]
                             return result, 200
                     else:
-                        tracker_attrs = \
-                            LocationData.get_tracker_attributes(sensor_id)
+                        tracker_attrs = LocationData.get_tracker_attributes(sensor_id)
                         if tracker_attrs:
-                            return {"id" : sensor_id,
-                                    "attributes": tracker_attrs}, 200
+                            return {"id": sensor_id,
+                                    "attributes": tracker_attrs
+                                    }, 200
 
                 if 'attribute' in args:
                     attr_name = args['attribute']
@@ -226,7 +230,8 @@ class RequestForData(Resource):
                         for track in trackers:
                             if LocationData.does_tracker_record(track.id,
                                                                 attr_name):
-                                tracker_data = {"id": track.id, "data":[]}
+
+                                tracker_data = {"id": track.id, "data": []}
                                 tracker_data_result = \
                                         LocationData.get_by_tracker_id_with_limit(track.id, limit)
                                 for entry in tracker_data_result:

--- a/Analytics/resources/request_for_data.py
+++ b/Analytics/resources/request_for_data.py
@@ -226,10 +226,12 @@ class RequestForData(Resource):
                         limit = args["limit"]
 
                     if 'sensorid' in args:
-                        trackers = [Tracker.get_by_tracker_id(args["sensorid"])]
+                        trackers = \
+                            [Tracker.get_by_tracker_id(args["sensorid"])]
                         if trackers == [None]:
-                            return {"message": "could not find sensor with "
-                                               "id {}".format(args["sensorid"])}, 400
+                            return {"message": "could not "
+                                               "find sensor with id {}".
+                                                format(args["sensorid"])}, 400
                     else:
                         trackers = Tracker.get_all()
 

--- a/Analytics/resources/request_for_data.py
+++ b/Analytics/resources/request_for_data.py
@@ -67,6 +67,7 @@ from models.unit import Unit
 from models.prediction_results import PredictionResults
 from models.user_predictions import UserPredictions
 from models.users import Users
+from models.pin_location_data import Tracker, LocationData
 from resources.helper_functions import is_number
 from resources.request_grouped import request_grouped_data, request_harmonised_data
 
@@ -109,15 +110,135 @@ class RequestForData(Resource):
                         choices=('long', 'wide', 'geo'),
                         store_missing=False)
     parser.add_argument('per_sensor', type=inputs.boolean, store_missing=False)
-    parser.add_argument('sensorid', type=str)
+    parser.add_argument('sensorid', type=str, store_missing = False)
     parser.add_argument('n_predictions', type=int, store_missing = False)
     parser.add_argument('predictions', type=inputs.boolean, store_missing = False)
     parser.add_argument('user_id', type=int, store_missing=False)
+    parser.add_argument('moving', type=inputs.boolean, required=False,
+                        store_missing = False)
 
     def get(self):
         args = self.parser.parse_args()
         theme, subtheme, attribute_data, sensor, sensor_name, sensor_attribute, attributes, sensorid, n_predictions, predictions, grouped, harmonising_method, per_sensor, freq, method = None, None, None, None, None, None, [], None, 100, None, None, None, None, '1H', 'mean'
         user_id = None
+
+        if 'moving' in args:
+            if args['moving']:
+                if 'theme' in args:
+                    theme_id = args['theme']
+                    if theme_id == 'all':
+                        themes = Theme.get_all()
+                        moving_themes = [theme.json() for theme in themes
+                                         if "Moving" in theme.name]
+                        return moving_themes, 200
+                    else:
+                        subthemes = SubTheme.get_by_theme_id(theme_id)
+                        if subthemes:
+                            moving_subthemes = [subtheme.json() for subtheme in
+                                                subthemes if "Moving"in subtheme.name]
+                            return moving_subthemes, 200
+                        else:
+                            return {"message": "could not find subthemes "
+                                               "corresponding to theme id "
+                                               "{}".format(theme_id)}, 400
+
+                if 'subtheme' in args:
+                    subtheme_id = args['subtheme']
+                    if subtheme_id == 'all':
+                        subthemes = SubTheme.get_all()
+                        moving_subthemes = [subtheme.json() for subtheme in
+                                            subthemes if "Moving"in subtheme.name]
+                        return moving_subthemes, 200
+                    else:
+                        trackers = Tracker.get_by_subtheme_id(subtheme_id)
+                        if trackers:
+                            moving_sensors = [tracker.json for tracker in trackers
+                                              if tracker.sub_theme_id == int(subtheme_id)]
+                            return moving_sensors, 200
+                        else:
+                            return {"message": "could not find sensors "
+                                               "corresponding to subtheme id "
+                                               "{}".format(subtheme_id)}, 400
+
+                if 'sensor' in args:
+                    sensor_id = args["sensor"]
+                    if sensor_id == "all":
+                        sensors = Tracker.get_all()
+                        if sensors:
+                            moving_sensors = [sensor.json for sensor in sensors]
+                            return moving_sensors, 200
+                        else:
+                            return {"message": "No moving sensors"}, 400
+                    else:
+                        moving_sensor = Tracker.get_by_tracker_id(sensor_id)
+                        if moving_sensor:
+                            return moving_sensor.json, 200
+                        else:
+                            return {"message": "could not find sensor with "
+                                               "id {}".format(sensor_id)}, 400
+
+                if 'sensorattribute' in args:
+                    sensor_id = args["sensorattribute"]
+                    if sensor_id == 'all':
+                        all_trackers =  Tracker.get_all()
+                        if all_trackers:
+                            result = [{"id": tracker.id,
+                                       "attributes" :
+                                           LocationData.get_tracker_attributes(tracker.id)}
+                                      for tracker in all_trackers]
+                            return result, 200
+                    else:
+                        tracker_attrs = \
+                            LocationData.get_tracker_attributes(sensor_id)
+                        if tracker_attrs:
+                            return {"id" : sensor_id,
+                                    "attributes": tracker_attrs}, 200
+
+                if 'attribute' in args:
+                    attr_name = args['attribute']
+                    all_trackers = Tracker.get_all()
+                    if all_trackers:
+                        result = {"attribute": attr_name, "trackers": []}
+                        for track in all_trackers:
+                            if LocationData.does_tracker_record(track.id,
+                                                                attr_name):
+                                result["trackers"].append({"id":track.id})
+                        return result, 200
+                    else:
+                        return {"message": "No moving sensors"}, 400
+
+                if 'attributedata' in args:
+                    limit = 5
+                    if 'limit' in args:
+                        limit = args["limit"]
+
+                    if 'sensorid' in args:
+                        trackers = [Tracker.get_by_tracker_id(args["sensorid"])]
+                        if trackers == [None]:
+                            return {"message": "could not find sensor with "
+                                               "id {}".format(args["sensorid"])}, 400
+                    else:
+                        trackers = Tracker.get_all()
+
+                    attr_name = args['attributedata']
+                    if trackers:
+                        result = {"attribute": attr_name, "attributedata": []}
+                        for track in trackers:
+                            if LocationData.does_tracker_record(track.id,
+                                                                attr_name):
+                                tracker_data = {"id": track.id, "data":[]}
+                                tracker_data_result = \
+                                        LocationData.get_by_tracker_id_with_limit(track.id, limit)
+                                for entry in tracker_data_result:
+                                    tracker_data["data"].append(entry.json)
+
+                                result["attributedata"].append(tracker_data)
+
+                        return result, 200
+                    else:
+                        return {"message": "No moving sensor"}, 400
+
+            return {"error": "error occurred while processing request"}, 400
 
         if 'theme' in args:
             theme = args['theme']

--- a/Analytics/resources/request_for_data.py
+++ b/Analytics/resources/request_for_data.py
@@ -71,7 +71,8 @@ from models.user_predictions import UserPredictions
 from models.users import Users
 from models.pin_location_data import Tracker, LocationData
 from resources.helper_functions import is_number
-from resources.request_grouped import request_grouped_data, request_harmonised_data
+from resources.request_grouped import request_grouped_data
+from resources.request_grouped import request_harmonised_data
 
 
 LIMIT = 30
@@ -114,7 +115,8 @@ class RequestForData(Resource):
     parser.add_argument('per_sensor', type=inputs.boolean, store_missing=False)
     parser.add_argument('sensorid', type=str, store_missing = False)
     parser.add_argument('n_predictions', type=int, store_missing = False)
-    parser.add_argument('predictions', type=inputs.boolean, store_missing = False)
+    parser.add_argument('predictions', type=inputs.boolean,
+                        store_missing = False)
     parser.add_argument('user_id', type=int, store_missing=False)
     parser.add_argument('moving', type=inputs.boolean, required=False,
                         store_missing = False)
@@ -137,7 +139,8 @@ class RequestForData(Resource):
                         subthemes = SubTheme.get_by_theme_id(theme_id)
                         if subthemes:
                             moving_subthemes = [subtheme.json() for subtheme in
-                                                subthemes if "Moving"in subtheme.name]
+                                                subthemes if "Moving"in
+                                                subtheme.name]
                             return moving_subthemes, 200
                         else:
                             return {"message": "could not find subthemes "
@@ -149,13 +152,16 @@ class RequestForData(Resource):
                     if subtheme_id == 'all':
                         subthemes = SubTheme.get_all()
                         moving_subthemes = [subtheme.json() for subtheme in
-                                            subthemes if "Moving"in subtheme.name]
+                                            subthemes if "Moving"in
+                                            subtheme.name]
                         return moving_subthemes, 200
                     else:
                         trackers = Tracker.get_by_subtheme_id(subtheme_id)
                         if trackers:
-                            moving_sensors = [tracker.json for tracker in trackers
-                                              if tracker.sub_theme_id == int(subtheme_id)]
+                            moving_sensors = [tracker.json for tracker in
+                                              trackers if
+                                              tracker.sub_theme_id ==
+                                              int(subtheme_id)]
                             return moving_sensors, 200
                         else:
                             return {"message": "could not find sensors "
@@ -167,7 +173,8 @@ class RequestForData(Resource):
                     if sensor_id == "all":
                         sensors = Tracker.get_all()
                         if sensors:
-                            moving_sensors = [sensor.json for sensor in sensors]
+                            moving_sensors = [sensor.json for sensor
+                                              in sensors]
                             return moving_sensors, 200
                         else:
                             return {"message": "No moving sensors"}, 400
@@ -187,12 +194,14 @@ class RequestForData(Resource):
                             result = [
                                 {"id": tracker.id,
                                  "attributes":
-                                     LocationData.get_tracker_attributes(tracker.id)
+                                     LocationData.get_tracker_attributes(
+                                         tracker.id)
                                  } for tracker in all_trackers
                             ]
                             return result, 200
                     else:
-                        tracker_attrs = LocationData.get_tracker_attributes(sensor_id)
+                        tracker_attrs = LocationData.get_tracker_attributes(
+                            sensor_id)
                         if tracker_attrs:
                             return {"id": sensor_id,
                                     "attributes": tracker_attrs
@@ -233,7 +242,8 @@ class RequestForData(Resource):
 
                                 tracker_data = {"id": track.id, "data": []}
                                 tracker_data_result = \
-                                        LocationData.get_by_tracker_id_with_limit(track.id, limit)
+                                        LocationData.get_by_tracker_id_with_limit(
+                                            track.id, limit)
                                 for entry in tracker_data_result:
                                     tracker_data["data"].append(entry.json)
 

--- a/Analytics/test_request_for_moving_sensor.py
+++ b/Analytics/test_request_for_moving_sensor.py
@@ -1,0 +1,47 @@
+import unittest
+from datetime import datetime
+
+from app import create_app
+from models.theme import Theme
+
+
+class RequestMovingSensorDataTestCase(unittest.TestCase):
+    """
+    Test whether an admin user can request for a retry of a failed importer
+    """
+
+    def setUp(self):
+        """ Create testing client version of flask app """
+
+        self.test_app = create_app(DATABASE_NAME='scheduler',
+                                   TESTING=True)
+        self.testing_client = self.test_app.test_client()
+        self.testing_client_context = self.test_app.app_context()
+        self.testing_client_context.push()
+
+    def tearDown(self):
+        """ Remove testing client context """
+
+        self.testing_client_context.pop()
+
+    def test_request_for_themes(self):
+        theme_param = 'all'
+        response = self.testing_client.get('/data?moving=True&theme=' +
+                                           theme_param)
+        self.assertIn(b"Moving_Sensor",response.data)
+
+    def test_request_for_subtheme(self):
+        subtheme_param = 'all'
+        response = self.testing_client.get('/data?moving=True&subtheme=' +
+                                           subtheme_param)
+        self.assertIn(b"Moving_Airquality", response.data)
+
+    def test_request_for_sensor(self):
+        sensor_param = 'all'
+        response = self.testing_client.get('/data?moving=True&sensor=' +
+                                           sensor_param)
+        self.assertIn(b"2018", response.data)
+        self.assertIn(b"2020", response.data)
+        self.assertIn(b"2021", response.data)
+        self.assertIn(b"2022", response.data)
+        self.assertIn(b"2025", response.data)

--- a/Analytics/test_request_for_moving_sensor.py
+++ b/Analytics/test_request_for_moving_sensor.py
@@ -1,8 +1,6 @@
 import unittest
-from datetime import datetime
 
 from app import create_app
-from models.theme import Theme
 
 
 class RequestMovingSensorDataTestCase(unittest.TestCase):
@@ -25,18 +23,30 @@ class RequestMovingSensorDataTestCase(unittest.TestCase):
         self.testing_client_context.pop()
 
     def test_request_for_themes(self):
+        """
+        Test whether the correct Theme is returned when the moving param
+        is set to True
+        """
         theme_param = 'all'
         response = self.testing_client.get('/data?moving=True&theme=' +
                                            theme_param)
         self.assertIn(b"Moving_Sensor",response.data)
 
     def test_request_for_subtheme(self):
+        """
+        Test whether the correct subtheme is returned when the moving param
+        is set to True
+        """
         subtheme_param = 'all'
         response = self.testing_client.get('/data?moving=True&subtheme=' +
                                            subtheme_param)
         self.assertIn(b"Moving_Airquality", response.data)
 
     def test_request_for_sensor(self):
+        """
+        Test whether the correct sensors are returned when the moving param
+        is set to True
+        """
         sensor_param = 'all'
         response = self.testing_client.get('/data?moving=True&sensor=' +
                                            sensor_param)


### PR DESCRIPTION
**Updated files** 

Analytics/models/pin_location_data.py
 1) added a subtheme field to the Tracker model 
 2) added class methods to return all trackers, trackers according to a subtheme id and the attributes a tracker records

Analytics/resources/moving_sensors/get_dummy_data.py - associated a tracker with a sub theme when it is imported into the database and made the trackers record a variety of dummy air quality data

Analytics/resources/request_for_data.py - added a moving argument that allows the user to specify that data related to moving sensors should be returned with respect to themes, subthemes, sensors and attributes

**New Files**
Analytics/test_request_for_moving_sensor.py - Test the functionality of the /data endpoint when the moving argument is True
