### PR TITLE
Alert widget final

### DIFF
--- a/Frontend/fcc.config.js
+++ b/Frontend/fcc.config.js
@@ -99,7 +99,7 @@ module.exports = {
     widgetName: "New Widget",
     widgetDescription: "",
     widgetType: "plot",
-    widgetWidth: 200,
+    widgetWidth: 300,
     widgetHeight: 200,
     widgetIsStatic: false,
   },

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -4541,9 +4541,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -9600,13 +9600,13 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -30,6 +30,7 @@
     "moment": "^2.24.0",
     "prop-types": "^15.7.1",
     "react": "^16.6.0",
+    "react-container-dimensions": "^1.4.1",
     "react-dom": "^16.6.0",
     "react-grid-layout": "^0.16.6",
     "react-leaflet": "^2.1.1",

--- a/Frontend/src/actions/editorActions.js
+++ b/Frontend/src/actions/editorActions.js
@@ -89,8 +89,6 @@ export const saveWidget = (mode, widget) => {
 
     axiosInstance.post("widgets/create_widget", requestData).then((response) => {
 
-      console.log('requestData', requestData)
-
       // hold off on updating dashboard if this is an alert widget - there's more to be done
       if (widget.type !== WIDGET_TYPE_ALERT) {
         dispatch(fetchWidgets());
@@ -103,12 +101,12 @@ export const saveWidget = (mode, widget) => {
       });
 
       // handle adding or updating alerts for alert widgets
+      // ToDo :: if updating alert widget from actual widget component no need to update the alert itself
       if (widget.type === WIDGET_TYPE_ALERT) {
         const alertPayload = {
-          activated: widget.config.activated,
+          activated: widget.config.triggered,
           attribute_id: widget.config.attributeId,
-          max_threshold: widget.config.maxThreshold,
-          min_threshold: widget.config.minThreshold,
+          [widget.config.type === "max" ? "max_threshold" : "min_threshold"]: widget.config.value,
         };
 
         let alertEndpoint = "/alert";

--- a/Frontend/src/components/Editor/preview/AlertPreview.js
+++ b/Frontend/src/components/Editor/preview/AlertPreview.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Fade,
   Table,
   TableBody,
   TableCell,
@@ -21,6 +20,14 @@ const styles = (theme) => ({
     maxHeight: 0,
     overflow: 'hidden',
   },
+  cellValue: {
+    color: theme.palette.primary.main,
+    textAlign: 'right',
+  },
+  cellTriggered: {
+    color: theme.palette.secondary.main,
+    textAlign: 'right',
+  },
 });
 
 class AlertPreview extends React.Component {
@@ -35,7 +42,7 @@ class AlertPreview extends React.Component {
 
     this.state = {
       error: null,
-      loading: true,
+      loading: false,
       attributes: [],
       width: props.editor.widget.width,
       height: props.editor.widget.height,
@@ -46,10 +53,6 @@ class AlertPreview extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const { editor } = this.props;
-
-    if (nextProps.editor.fetching !== editor.fetching) {
-      this.setState({ loading: nextProps.editor.fetching })
-    }
 
     if (nextProps.editor.themeTree !== editor.themeTree) {
       const attributes = nextProps.editor.themeTree.reduce((arr, theme) => {
@@ -85,7 +88,7 @@ class AlertPreview extends React.Component {
 
   render() {
     const { classes, editor } = this.props;
-    const { error, loading } = this.state;
+    const { loading } = this.state;
 
     if (loading) {
       return (
@@ -103,29 +106,30 @@ class AlertPreview extends React.Component {
     };
 
     return (
-      <div className={classes.root} style={rootStyles}>
-        <Fade in={!loading} mountOnEnter>
-          <Table padding="none">
-            <TableBody>
-              <TableRow>
-                <TableCell component="th" scope="row">Attribute</TableCell>
-                <TableCell>{this.getAttributeNameFromId(editor.widget.config.attributeId)}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell component="th" scope="row">Minimum threshold</TableCell>
-                <TableCell>{editor.widget.config.minThreshold}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell component="th" scope="row">Maximum threshold</TableCell>
-                <TableCell>{editor.widget.config.maxThreshold}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell component="th" scope="row">Activated</TableCell>
-                <TableCell>{editor.widget.config.activated.toString()}</TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </Fade>
+      <div className={classes.root}  style={rootStyles}>
+        <Table padding="none">
+          <TableBody>
+            <TableRow>
+              <TableCell component="th" scope="row">Attribute</TableCell>
+              <TableCell className={classes.cellValue}>{this.getAttributeNameFromId(editor.widget.config.attributeId)}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell component="th" scope="row">Alert type</TableCell>
+              <TableCell className={classes.cellValue}>{editor.widget.config.type} threshold</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell component="th" scope="row">Threshold value</TableCell>
+              <TableCell className={classes.cellValue}>{editor.widget.config.value}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell component="th" scope="row">Status</TableCell>
+              {editor.widget.config.triggered.toString() === 'true'
+                ? <TableCell className={classes.cellTriggered}>{editor.widget.config.triggerEvent.message}<br />at {editor.widget.config.triggerEvent.timestamp}</TableCell>
+                : <TableCell className={classes.cellValue}>alert active</TableCell>
+              }
+            </TableRow>
+          </TableBody>
+        </Table>
       </div>
     )
   }

--- a/Frontend/src/components/Editor/preview/AlertPreview.js
+++ b/Frontend/src/components/Editor/preview/AlertPreview.js
@@ -125,7 +125,7 @@ class AlertPreview extends React.Component {
               <TableCell component="th" scope="row">Status</TableCell>
               {editor.widget.config.triggered.toString() === 'true'
                 ? <TableCell className={classes.cellTriggered}>{editor.widget.config.triggerEvent.message}<br />at {editor.widget.config.triggerEvent.timestamp}</TableCell>
-                : <TableCell className={classes.cellValue}>alert active</TableCell>
+                : <TableCell className={classes.cellValue}>active</TableCell>
               }
             </TableRow>
           </TableBody>

--- a/Frontend/src/components/Widget/AlertWidget.js
+++ b/Frontend/src/components/Widget/AlertWidget.js
@@ -198,7 +198,7 @@ class AlertWidget extends React.Component {
                 <TableCell component="th" scope="row">Status</TableCell>
                 {config.triggered.toString() === 'true'
                   ? <TableCell className={classes.cellTriggered}>{config.triggerEvent.message}<br />at {config.triggerEvent.timestamp}</TableCell>
-                  : <TableCell className={classes.cellValue}>alert active</TableCell>
+                  : <TableCell className={classes.cellValue}>active</TableCell>
                 }
             </TableRow>
             </TableBody>

--- a/Frontend/src/components/Widget/AlertWidget.js
+++ b/Frontend/src/components/Widget/AlertWidget.js
@@ -8,6 +8,8 @@ import {
   TableRow,
   withStyles,
 } from '@material-ui/core';
+import { connect } from 'react-redux';
+import { saveWidget } from './../../actions/editorActions';
 import { axiosInstance } from './../../api/axios';
 import { getUserID } from './../../api/session';
 import WidgetWrapper from './WidgetWrapper';
@@ -15,14 +17,14 @@ import WidgetWrapper from './WidgetWrapper';
 const styles = (theme) => ({
   root: {
     transition: 'all 0.2s ease',
-    //width: 'auto',
-    //height: '100%',
-    //maxWidth: 0,
-    //maxHeight: 0,
     overflow: 'hidden',
   },
   cellValue: {
     color: theme.palette.primary.main,
+    textAlign: 'right',
+  },
+  cellTriggered: {
+    color: theme.palette.secondary.main,
     textAlign: 'right',
   },
 });
@@ -30,7 +32,6 @@ const styles = (theme) => ({
 class AlertWidget extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
-    theme: PropTypes.object.isRequired,
     name: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     width: PropTypes.number.isRequired,
@@ -50,22 +51,28 @@ class AlertWidget extends React.Component {
       attributes: [],
     };
 
-    this.eventSource = null;
+    this.intervalTimer = null;
   }
 
   componentDidMount() {
     this.getAllAttributes();
-    this.connectToSSE();
   }
 
   componentWillUnmount() {
-    if (this.eventSource) {
-      this.eventSource.close();
-      this.eventSource = null;
-    }
+    this.killTimer(this.intervalTimer)
   }
 
+  killTimer = (timer) => {
+    if (timer) {
+      clearInterval(timer);
+
+      timer = null;
+    }
+  };
+
   getAllAttributes = () => {
+    const { config } = this.props;
+
     this.setState({ loading: true });
 
     axiosInstance
@@ -74,6 +81,14 @@ class AlertWidget extends React.Component {
         this.setState({
           attributes: response.data,
           loading: false,
+        }, () => {
+
+          // no need to check status if alert is already triggered
+          if (config.triggered.toString() === "false") {
+            this.intervalTimer = setInterval(this.checkAlertStatus, 10000);
+
+            this.checkAlertStatus()
+          }
         })
       })
       .catch((error) => {
@@ -85,33 +100,62 @@ class AlertWidget extends React.Component {
     ;
   };
 
-  connectToSSE() {
-    if (this.eventSource === null) {
-      const apiUrl = `${process.env.API_HOST}`;
-      const path = '/alert/triggered';
-      const userID = getUserID();
-      const args = `?user_id=${userID}`;
+  checkAlertStatus = () => {
+    const { i, type, name, description, isStatic, width, height, w, h, config, queryParams, saveWidget } = this.props;
 
-      this.eventSource = new EventSource(`${apiUrl}${path}${args}`);
-      this.eventSource.onerror = (err) => {
-        console.log(err);
-      };
-      this.eventSource.onmessage = (e) => {
-        console.log(e);
+    axiosInstance
+      .get('/alert/check_alerts', {
+        params: {
+          attribute_id: config.attributeId,
+          user_id: getUserID(),
+        }
+      })
+      .then((response) => {
+        if (response.data[config.type].length) {
+          const triggeredAlert = response.data[config.type].find((alert) => alert.id === config.alertId);
 
-        // ToDo :: handle the updated widget state here. Currently I'm not aware of the response format
-      }
-    }
+          if (triggeredAlert) {
+
+            // kill the timer
+            this.killTimer(this.intervalTimer);
+
+            // rebuild a widget object with the updated alert info
+            const widget = {
+              type,
+              name,
+              description,
+              width,
+              height,
+              w,
+              h,
+              isStatic,
+              config: {
+                ...config,
+                triggered: true,
+                triggerEvent: {
+                  ...config.triggerEvent,
+                  message: triggeredAlert['type'],
+                  value: triggeredAlert['value'],
+                  timestamp: triggeredAlert['timestamp'],
+                }
+              },
+              queryParams,
+              i,
+            };
+
+            // get the editor to save it in "edit" mode
+            saveWidget('edit', widget)
+          }
+        }
+      })
+      .catch((err) => {
+        this.setState({ error: err.response })
+      })
   };
 
   render() {
-    const { classes, theme, i, type, name, description, isStatic, width, height, config, queryParams } = this.props;
-    const { loading, error } = this.state;
-
-    const tableStyles = {
-      //width: `${width}px`,
-      //height: `${height}px`,
-    };
+    const { classes, i, type, name, description, isStatic, width, height, w, h, config, queryParams } = this.props;
+    const { loading } = this.state;
 
     const getAttributeNameFromId = (attributeId) => {
       const { attributes } = this.state;
@@ -130,28 +174,33 @@ class AlertWidget extends React.Component {
         isStatic={isStatic}
         width={width}
         height={height}
+        w={w}
+        h={h}
         config={config}
         queryParams={queryParams}
       >
         <Fade in={!loading} mountOnEnter>
-          <Table className={classes.root} padding="none" style={tableStyles}>
+          <Table className={classes.root} padding="none">
             <TableBody>
               <TableRow>
-                <TableCell component="th" scope="row">Attribute</TableCell>
+                <TableCell component="th" scope="row">Watched attribute</TableCell>
                 <TableCell className={classes.cellValue}>{getAttributeNameFromId(config.attributeId)}</TableCell>
               </TableRow>
               <TableRow>
-                <TableCell component="th" scope="row">Minimum threshold</TableCell>
-                <TableCell className={classes.cellValue}>{config.minThreshold}</TableCell>
+                <TableCell component="th" scope="row">Alert type</TableCell>
+                <TableCell className={classes.cellValue}>{config.type} threshold</TableCell>
               </TableRow>
               <TableRow>
-                <TableCell component="th" scope="row">Maximum threshold</TableCell>
-                <TableCell className={classes.cellValue}>{config.maxThreshold}</TableCell>
+                <TableCell component="th" scope="row">Threshold value</TableCell>
+                <TableCell className={classes.cellValue}>{config.value}</TableCell>
               </TableRow>
               <TableRow>
-                <TableCell component="th" scope="row">Activated</TableCell>
-                <TableCell className={classes.cellValue}>{config.activated.toString()}</TableCell>
-              </TableRow>
+                <TableCell component="th" scope="row">Status</TableCell>
+                {config.triggered.toString() === 'true'
+                  ? <TableCell className={classes.cellTriggered}>{config.triggerEvent.message}<br />at {config.triggerEvent.timestamp}</TableCell>
+                  : <TableCell className={classes.cellValue}>alert active</TableCell>
+                }
+            </TableRow>
             </TableBody>
           </Table>
         </Fade>
@@ -160,6 +209,11 @@ class AlertWidget extends React.Component {
   }
 }
 
-AlertWidget = withStyles(styles, { withTheme: true })(AlertWidget);
+const mapDispatchToProps  = (dispatch) => ({
+  saveWidget: (mode, widget) => dispatch(saveWidget(mode, widget)),
+});
+
+AlertWidget = withStyles(styles)(AlertWidget);
+AlertWidget = connect(null, mapDispatchToProps)(AlertWidget);
 
 export default AlertWidget

--- a/Frontend/src/reducers/editor.js
+++ b/Frontend/src/reducers/editor.js
@@ -50,9 +50,14 @@ const getWidgetDefaultProperties = (currentProperties) => {
           ...defaultProperties.config,
           alertId: null,
           attributeId: null,
-          activated: true,
-          maxThreshold: null,
-          minThreshold: null,
+          triggered: false,
+          triggerEvent: {
+            message: "",
+            value: null,
+            timestamp: null,
+          },
+          type: "max",
+          value: 0,
         },
       }
     }


### PR DESCRIPTION
### Frontend/fcc.config.js
- increased default widget pixel width from 200 to 300

### Frontend/package.json
- added `react-container-dimensions` package to dependencies

### Frontend/src/actions/editorActions.js
- updated payload object sent to `/alert/create_alert` and `/alert/update_alert` 

### Frontend/src/components/Editor/config/AlertConfig.js
- if an existing widget is being edited (as opposed to a widget being created) the `/alert/check_alerts` endpoint is called and the response compared to the widget's `config` data - updating it (but not saving it) as required,
- ui form updated so only one alert "type" (min/max) can be set for the widget,

### Frontend/src/components/Editor/preview/AlertPreview.js
- removed fade in/out effect as it was leaving the component contents blurry,
- small styling tweaks,
- updated table to reflect a single alert type (min/max) and to display alert "status",

### Frontend/src/components/Widget/AlertWidget.js
- uses it's own stored `config` data initially when loaded,
- unless alert is "triggered" it checks for updated status from `/alert/check_alerts` on a loop until the alert is "triggered",
- if response from `/alert/check_alerts` indicates that the alert has been triggered the widget's `config` is updated and saved and the new status is displayed,
- small styling tweaks,
- updated table to reflect a single alert type (min/max) and to display alert "status" ( as per `AlertPreview`),
- updated dimensions to reflect new `react-container-dimensions` based layout

### Frontend/src/reducers/editor.js
- updated the default alert widget default `config` object